### PR TITLE
Update biasRatings.js

### DIFF
--- a/content_scripts/data/biasRatings.js
+++ b/content_scripts/data/biasRatings.js
@@ -1068,5 +1068,20 @@ window.biasRatings = {
         "title": "Hampton Roads Messanger",
         "rating": "Center",
         "url": "http://www.hamptonroadsmessenger.com/"
+    },
+    "counterpunch.org": {
+        "title": "CounterPunch",
+        "rating": "Lean Left",
+        "url": "http://www.counterpunch.org/"
+    },
+    "therealnews.com": {
+        "title": "The Real News Network",
+        "rating": "Lean Left",
+        "url": "http://therealnews.com/"
+    },
+    "tyt.com": {
+        "title": "The Young Turks",
+        "rating": "Lean Left",
+        "url": "http://therealnews.com/"
     }
 }


### PR DESCRIPTION
Added CounterPunch, The Real News, and The Young Turks ratins from swprs.org.  Still haven't gotten to: "Liberal & distant", "Center & close", "Center & distant", "Conservative & close", "Conservative & intermediate", and "Conservative & distant" outlets. I based lean left vs. left designations on this chart with only the top and bottom rows qualifying as non-lean left or right: https://swprs.files.wordpress.com/2020/02/media-navigator.png